### PR TITLE
Add working time countdown and flexible in game screen

### DIFF
--- a/code/Lifelink/app/src/main/java/com/lifelink/lifelink/InLobby.java
+++ b/code/Lifelink/app/src/main/java/com/lifelink/lifelink/InLobby.java
@@ -2,6 +2,7 @@ package com.lifelink.lifelink;
 
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.graphics.Color;
 import android.support.v4.app.FragmentActivity;
 import android.os.Bundle;
 import android.util.Log;
@@ -9,7 +10,10 @@ import android.view.View;
 import android.widget.Button;
 import android.net.wifi.p2p.WifiP2pManager;
 import android.net.wifi.p2p.WifiP2pManager.Channel;
+import android.widget.TextView;
 import android.widget.Toast;
+
+import org.w3c.dom.Text;
 
 
 /**
@@ -20,6 +24,8 @@ import android.widget.Toast;
  */
 public class InLobby extends FragmentActivity implements
         WifiP2pManager.ChannelListener {
+
+    private int numberOfPlayers;
 
     public static final String TAG = "InLobbyActivity";
 
@@ -45,6 +51,8 @@ public class InLobby extends FragmentActivity implements
         super.onCreate(savedInstanceState);
         Log.d(TAG, "This should print");
         setContentView(R.layout.activity_inlobby);
+
+        numberOfPlayers = 1;
 
         // Adds broadcast to the IntentFilter when the Wi-Fi P2P status is changed.
         intentFilter.addAction(WifiP2pManager.WIFI_P2P_STATE_CHANGED_ACTION);
@@ -81,7 +89,11 @@ public class InLobby extends FragmentActivity implements
             }
         });
 
-        // Button to start the game.
+        final TextView numberOfPlayersValueView = (TextView) findViewById(R.id.numberOfPlayersValue);
+
+
+
+                // Button to start the game.
         Button startGame = (Button) findViewById(R.id.startGame);
         startGame.setOnClickListener(new View.OnClickListener() {
             /**
@@ -91,6 +103,8 @@ public class InLobby extends FragmentActivity implements
             @Override
             public void onClick(View view) {
                 Intent intent = new Intent(InLobby.this, Ingame.class);
+                numberOfPlayers = Integer.parseInt(numberOfPlayersValueView.getText().toString());
+                intent.putExtra("NUMBER_OF_PLAYERS", numberOfPlayers);
                 startActivity(intent);
             }
         });

--- a/code/Lifelink/app/src/main/res/layout/activity_ingame.xml
+++ b/code/Lifelink/app/src/main/res/layout/activity_ingame.xml
@@ -58,7 +58,8 @@
         android:text="@string/opponent1"
         android:textAlignment="center"
         android:textColor="@color/white"
-        android:textSize="18sp" />
+        android:textSize="18sp"
+        android:visibility="visible"/>
 
     <TextView
         android:id="@+id/Opponent3"
@@ -73,7 +74,8 @@
         android:text="@string/opponent3"
         android:textAlignment="center"
         android:textColor="@color/white"
-        android:textSize="18sp" />
+        android:textSize="18sp"
+        android:visibility="visible"/>
 
     <TextView
         android:id="@+id/Opponent2"
@@ -86,13 +88,14 @@
         android:textColor="@color/white"
         android:textAlignment="center"
         android:textSize="18sp"
-        android:layout_above="@+id/OpponentLife1" />
+        android:layout_above="@+id/OpponentLife1"
+        android:visibility="visible"/>
 
     <TextView
         android:id="@+id/OpponentLife1"
         android:layout_width="150dp"
         android:layout_height="150dp"
-        android:text="@string/_10"
+        android:text="1"
         android:textAlignment="center"
         android:textSize="60sp"
         android:layout_below="@+id/Opponent1"
@@ -101,33 +104,35 @@
         android:layout_alignParentStart="true"
         android:layout_alignBottom="@+id/OpponentLife3"
         android:layout_toLeftOf="@+id/Opponent2"
-        android:layout_toStartOf="@+id/Opponent2" />
+        android:layout_toStartOf="@+id/Opponent2"
+        android:visibility="visible" />
 
     <TextView
         android:id="@+id/OpponentLife2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/_20"
+        android:text="2"
         android:textAlignment="center"
         android:textColor="@color/white"
         android:textSize="60sp"
         android:layout_below="@+id/Opponent2"
         android:layout_toRightOf="@+id/OpponentLife1"
         android:layout_toLeftOf="@+id/OpponentLife3"
-        />
+        android:visibility="visible" />
 
     <TextView
         android:id="@+id/OpponentLife3"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/_30"
+        android:text="3"
         android:textAlignment="center"
         android:textSize="60sp"
         android:layout_below="@+id/Opponent3"
         android:layout_toRightOf="@+id/Opponent2"
         android:textColor="@color/white"
         android:layout_alignParentRight="true"
-        android:layout_alignParentEnd="true" />
+        android:layout_alignParentEnd="true"
+        android:visibility="visible"/>
 
     <Button
         android:id="@+id/pass"
@@ -148,12 +153,12 @@
         android:id="@+id/time"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:text="time"
+        android:textColor="@color/white"
+        android:textSize="45sp"
         android:layout_alignBaseline="@+id/pass"
         android:layout_alignBottom="@+id/pass"
         android:layout_alignLeft="@+id/minus1"
-        android:layout_alignStart="@+id/minus1"
-        android:text="@string/_1_30"
-        android:textColor="@color/white"
-        android:textSize="45sp" />
+        android:layout_alignStart="@+id/minus1" />
 
 </RelativeLayout>

--- a/code/Lifelink/app/src/main/res/layout/activity_inlobby.xml
+++ b/code/Lifelink/app/src/main/res/layout/activity_inlobby.xml
@@ -27,6 +27,27 @@
         </fragment>
     </LinearLayout>
 
+    <TextView
+        android:id="@+id/numberOfPlayersTextInfo"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Number of players: "
+        android:layout_marginBottom="83dp"
+        android:layout_above="@+id/startGame"
+        android:layout_centerHorizontal="true"
+        android:textColor="@color/white"/>
+
+    <EditText
+        android:id="@+id/numberOfPlayersValue"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="1"
+        android:textColor="@color/white"
+        android:layout_alignTop="@+id/numberOfPlayersTextInfo"
+        android:layout_centerHorizontal="true"
+        android:layout_marginTop="40dp"
+        android:background="@android:color/transparent" />
+
     <!--
         Button to start the game.
     -->


### PR DESCRIPTION
Add:

- Working countdown that can be paused and resumed with button press.

- Countdown starts at the set time in "creating lobby" screen.

- Flexible InGame screen, number of opponents listed depends on number of connected opponents.

- Opponents starting life start at the set value by the host.

- A way for the host to input number of connected users in InLobby screen so testing the features become easier.