### PR TITLE
Hotfix timer

### DIFF
--- a/code/Lifelink/app/src/main/java/com/lifelink/lifelink/Ingame.java
+++ b/code/Lifelink/app/src/main/java/com/lifelink/lifelink/Ingame.java
@@ -150,6 +150,16 @@ public class Ingame extends AppCompatActivity {
             }
         });
 
+        // Hide time settings if they are turned off
+        boolean timeOn = Boolean.parseBoolean(playerProfile.getString("timeOn", "true"));
+        if (!timeOn) {
+            timeDisplay.setVisibility(View.INVISIBLE);
+            timeButton.setVisibility(View.INVISIBLE);
+        } else {
+            timeDisplay.setVisibility(View.VISIBLE);
+            timeButton.setVisibility(View.VISIBLE);
+        }
+
         // Plus buttons
         Button plus1 = (Button) findViewById(R.id.plus1);
         plus1.setOnTouchListener(new View.OnTouchListener() {

--- a/code/Lifelink/app/src/main/java/com/lifelink/lifelink/Ingame.java
+++ b/code/Lifelink/app/src/main/java/com/lifelink/lifelink/Ingame.java
@@ -36,6 +36,7 @@ public class Ingame extends AppCompatActivity {
     private TextView timeDisplay;
 
     private boolean timeTicking;
+    private int startingTime;
     private int currentTime;
     private CountDownTimer countDownTimer;
 
@@ -126,12 +127,11 @@ public class Ingame extends AppCompatActivity {
 
         // Set starting time
         timeDisplay = (TextView) findViewById(R.id.time);
-        int startingTime = Integer.parseInt(playerProfile.getString("preferredTime","120"));
+        startingTime = Integer.parseInt(playerProfile.getString("preferredTime","120"));
         setTime(startingTime);
-        currentTime = startingTime;
 
-        timeTicking = true;
-        newCountDownTimer();
+        currentTime = startingTime;
+        timeTicking = false;
 
         // Time buttons
         final Button timeButton = (Button) findViewById(R.id.pass);
@@ -139,7 +139,7 @@ public class Ingame extends AppCompatActivity {
             @Override
             public void onClick(View view) {
                 if (timeTicking) {
-                    timeButton.setText("Resume turn");
+                    timeButton.setText("Start");
                     timeTicking = false;
                     stopCountDownTimer();
                 } else {
@@ -258,10 +258,12 @@ public class Ingame extends AppCompatActivity {
             return;
         }
         countDownTimer.cancel();
+        currentTime = startingTime;
+        setTime(startingTime    );
     }
 
     private void newCountDownTimer() {
-        countDownTimer = new CountDownTimer(currentTime*1000 + 1000, 1000) {
+        countDownTimer = new CountDownTimer(startingTime*1000 + 1000, 1000) {
 
             @Override
             public void onTick(long millisUntilFinished) {
@@ -288,7 +290,11 @@ public class Ingame extends AppCompatActivity {
         time = amount;
         int minutes = (int)Math.floor(time/60);
         int seconds = time - 60*minutes;
-        timeDisplay.setText("" + minutes + ":" + seconds);
+        String extraZero = "";
+        if (seconds < 10) {
+            extraZero = "0";
+        }
+        timeDisplay.setText("" + minutes + ":" + extraZero + seconds);
     }
 
     private void setOpponenOneInvisible() {

--- a/code/Lifelink/app/src/main/java/com/lifelink/lifelink/LobbyCreation.java
+++ b/code/Lifelink/app/src/main/java/com/lifelink/lifelink/LobbyCreation.java
@@ -17,6 +17,8 @@ import android.widget.Button;
  */
 public class LobbyCreation extends AppCompatActivity {
 
+    private boolean timeOn;
+
     /**
      * Called when the instance is first created.
      * @param savedInstanceState the previous instant state.
@@ -100,8 +102,9 @@ public class LobbyCreation extends AppCompatActivity {
             }
         });
 
+        timeOn = Boolean.parseBoolean(playerProfile.getString("timeOn", "true"));
          // Toggle time settings on/off.
-        ToggleButton timeOnOff = (ToggleButton) findViewById(R.id.setTimeOnOff);
+        final ToggleButton timeOnOff = (ToggleButton) findViewById(R.id.setTimeOnOff);
         final TextView timeText = (TextView) findViewById(R.id.timeText);
         timeOnOff.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
             public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
@@ -111,12 +114,14 @@ public class LobbyCreation extends AppCompatActivity {
                     currentTimeValue.setVisibility(View.VISIBLE);
                     setTimeValue.setVisibility(View.VISIBLE);
                     timeText.setVisibility(View.VISIBLE);
+                    timeOn = true;
                 } else {
                     // The toggle is disabled
                     // Hide all time settings
                     currentTimeValue.setVisibility(View.INVISIBLE);
                     setTimeValue.setVisibility(View.INVISIBLE);
                     timeText.setVisibility(View.INVISIBLE);
+                    timeOn = false;
                 }
             }
         });
@@ -134,6 +139,7 @@ public class LobbyCreation extends AppCompatActivity {
                 SharedPreferences.Editor editor = playerProfile.edit();
                 editor.putString("preferredLife", currentLifeCount.getText().toString());
                 editor.putString("preferredTime", currentTimeValue.getText().toString());
+                editor.putString("timeOn", String.valueOf(timeOn));
 
                 editor.apply();
 

--- a/code/Lifelink/app/src/main/res/layout/activity_ingame.xml
+++ b/code/Lifelink/app/src/main/res/layout/activity_ingame.xml
@@ -141,7 +141,7 @@
         android:layout_marginBottom="27dp"
         android:backgroundTint="@color/green"
         android:fontFamily="monospace"
-        android:text="@string/pass_turn"
+        android:text="Start"
         android:textSize="25sp"
         android:textStyle="bold"
         android:textColor="@color/white"


### PR DESCRIPTION
Add:

- Changes so that the timer resets after the turn is passed and the text is changed from "resume turn" to "start".

- Functionality via shared preferences so that the time display and button are hidden if the time settings are turned off in the create lobby page.

